### PR TITLE
WIP: Add Python3 support

### DIFF
--- a/plugin.video.amazon-test/default.py
+++ b/plugin.video.amazon-test/default.py
@@ -20,7 +20,7 @@ import xbmcplugin
 import xbmcgui
 import xbmcaddon
 import xbmc
-import urlparse
+import urllib.parse
 import time
 import subprocess
 import hashlib


### PR DESCRIPTION
"Starting from Kodi 18 (Leia), only addons that are compatible with both Python 2 and 3 will be accepted to the official addon repository."

See https://kodi.tv/article/attention-addon-developers-migration-python-3